### PR TITLE
Catch HTTP subpage links

### DIFF
--- a/mega.js
+++ b/mega.js
@@ -30,6 +30,7 @@ chrome.webRequest.onBeforeRequest.addListener(
 		    }
 	    }
 			else if (details.url.indexOf('https://mega.nz/') > -1 && details.url.length > 16) hash = '#' + details.url.split('https://mega.nz/')[1];
+			else if (details.url.indexOf('http://mega.nz/') > -1 && details.url.length > 15) hash = '#' + details.url.split('http://mega.nz/')[1];
             return { redirectUrl:  chrome.extension.getURL("mega/secure.html" + hash) };
         }
     },


### PR DESCRIPTION
From my testing with the chrome extension. If a user typed `mega.nz/help` into the address bar it would redirect them to the landing page of the extension rather than the help subpage. This was true for all the subpages that I tried. I traced this down to the extension script not picking up on http links. 

I have added a handler for http links to address this issue.