### PR TITLE
Fix Incognito mode

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,7 @@
   "description": "Secure Cloud Storage and Chat",
   "version": "109101.103.97",
   "content_security_policy": "script-src 'self' https://*.mega.co.nz https://*.mega.nz blob:; object-src 'self' https://*.mega.co.nz https://*.mega.nz blob:;",
+  "incognito": "split",
   "nacl_modules": [{
     "path": "mega",
     "mime_type": "text/html"


### PR DESCRIPTION
Fixes #8 
Specifies split mode to make chrome incognito work

This breaks the firefox extension, as firefox doesn't support `split` see [bug 1380812](https://bugzil.la/1380812)